### PR TITLE
ci: add Astro build and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy Astro to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: portfolio-astro/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: portfolio-astro
+
+      - name: Build
+        run: npm run build
+        working-directory: portfolio-astro
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: portfolio-astro/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds `.nojekyll` to stop GitHub Pages from running Jekyll on the repo
- Adds `deploy.yml` workflow that builds the Astro site and deploys `dist/` to Pages on push to `main`

## Requirements

In repo **Settings → Pages**, source must be set to **GitHub Actions** (not "Deploy from a branch").

## Test plan

- [ ] Merge and verify the Actions workflow runs successfully
- [ ] Confirm the site is live at barnola.net / barnolacesc.github.io/portfolio