### PR TITLE
feat: fixed sidebar on desktop, only content scrolls

### DIFF
--- a/portfolio-astro/src/layouts/Layout.astro
+++ b/portfolio-astro/src/layouts/Layout.astro
@@ -47,22 +47,8 @@ const {
     </div>
 
     <script>
-      // Visual overflow debugger — highlights offending elements in red
-      const vw = document.documentElement.clientWidth;
-      const offenders: string[] = [];
-      document.querySelectorAll('*').forEach(el => {
-        const rect = (el as HTMLElement).getBoundingClientRect();
-        if (rect.right > vw + 1 || rect.left < -1) {
-          (el as HTMLElement).style.outline = '2px solid red';
-          offenders.push(`${el.tagName} .${[...el.classList].join('.')} right=${Math.round(rect.right)} left=${Math.round(rect.left)}`);
-        }
-      });
-      if (offenders.length) {
-        const div = document.createElement('div');
-        div.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:red;color:white;font-size:11px;padding:6px;z-index:99999;word-break:break-all;max-height:120px;overflow-y:auto;';
-        div.textContent = offenders.join(' | ');
-        document.body.appendChild(div);
-      }
+      const isDesktop = () => window.innerWidth > 860;
+      const contentEl = document.querySelector<HTMLElement>('.content');
 
       // Active section tracking
       const sections = document.querySelectorAll('section[id]');
@@ -81,7 +67,7 @@ const {
             }
           });
         },
-        { threshold: 0.35 }
+        { root: isDesktop() ? contentEl : null, threshold: 0.35 }
       );
 
       sections.forEach((s) => sectionObserver.observe(s));
@@ -97,7 +83,7 @@ const {
             }
           });
         },
-        { threshold: 0.05, rootMargin: '0px 0px -32px 0px' }
+        { root: isDesktop() ? contentEl : null, threshold: 0.05, rootMargin: '0px 0px -32px 0px' }
       );
 
       document.querySelectorAll('.reveal').forEach((el) => revealObserver.observe(el));
@@ -116,8 +102,21 @@ const {
             if (start < target) requestAnimationFrame(tick);
           };
           requestAnimationFrame(tick);
-        });
+        }, { root: isDesktop() ? contentEl : null });
         obs.observe(el);
+      });
+
+      // Anchor link scrolling on desktop (content div is the scroll container)
+      document.querySelectorAll<HTMLAnchorElement>('a[href^="#"]').forEach((anchor) => {
+        anchor.addEventListener('click', (e) => {
+          if (!isDesktop() || !contentEl) return;
+          const id = anchor.getAttribute('href')!.slice(1);
+          const target = document.getElementById(id);
+          if (target) {
+            e.preventDefault();
+            target.scrollIntoView({ behavior: 'smooth' });
+          }
+        });
       });
     </script>
   </body>

--- a/portfolio-astro/src/styles/global.css
+++ b/portfolio-astro/src/styles/global.css
@@ -62,14 +62,14 @@ body::before {
   border-left: 1px solid var(--border);
   border-right: 1px solid var(--border);
   min-height: 100vh;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 .site-layout {
   display: grid;
   grid-template-columns: var(--sidebar-w) 1fr;
   min-height: 100vh;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 .sidebar {
@@ -88,6 +88,35 @@ body::before {
   min-height: 100vh;
   overflow-x: hidden;
   min-width: 0;
+}
+
+/* ── Desktop: fixed sidebar, scrollable content ── */
+@media (min-width: 861px) {
+  html,
+  body {
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .site-outer {
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .site-layout {
+    height: 100vh;
+  }
+
+  .sidebar {
+    position: static;
+  }
+
+  .content {
+    height: 100vh;
+    overflow-y: scroll;
+    scroll-behavior: smooth;
+    min-height: unset;
+  }
 }
 
 /* ── Typography ────────────────────────────── */


### PR DESCRIPTION
## Summary
- Sidebar stays fixed on desktop while only the content area scrolls
- Changed `overflow-x: hidden` → `clip` on layout containers so `position: sticky` isn't broken
- Added desktop media query locking `body` and making `.content` the scroll container
- Updated all `IntersectionObserver` instances to use `.content` as root on desktop
- Added anchor click handler so `#hash` links scroll within `.content` correctly

## Test plan
- [ ] Scroll the page on desktop — sidebar stays fixed, content scrolls
- [ ] Click nav links — smooth scroll to sections works
- [ ] Scroll reveal animations trigger correctly
- [ ] Mobile layout unchanged (sidebar hidden, normal page scroll)