### PR TITLE
fix(dockyard): use real setup/run config schema for Astro app

### DIFF
--- a/.dockyard.json
+++ b/.dockyard.json
@@ -1,6 +1,5 @@
 {
-  "preview": {
-    "command": "cd portfolio-astro && npm run dev -- --port 52355",
-    "port": 52355
-  }
+  "setup": "cd portfolio-astro && npm install",
+  "run": "cd portfolio-astro && npm run dev",
+  "expectedPort": 4321
 }


### PR DESCRIPTION
The existing `.dockyard.json` used a `preview`/`port` schema that Dockyard's loader (`ScriptConfig.loadDockyard`) doesn't read, so no setup/run scripts were registered.

Switched to the supported keys, targeting `portfolio-astro/`:
- `setup`: `cd portfolio-astro && npm install`
- `run`: `cd portfolio-astro && npm run dev`
- `expectedPort`: 4321 (Astro default; dy-run also auto-detects)