### PR TITLE
feat: link public homelab infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy Astro to GitHub Pages
 
 on:
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:
@@ -46,7 +45,6 @@ jobs:
           path: portfolio-astro/dist
 
   deploy:
-    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy Astro to GitHub Pages
 
 on:
+  pull_request:
   push:
     branches: [main]
   workflow_dispatch:
@@ -45,6 +46,7 @@ jobs:
           path: portfolio-astro/dist
 
   deploy:
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/portfolio-astro/src/components/Homelab.astro
+++ b/portfolio-astro/src/components/Homelab.astro
@@ -3,11 +3,10 @@ const namespaces = [
   { ns: 'media',        apps: ['Jellyfin', 'Radarr', 'Sonarr', 'Prowlarr', 'Bazarr', 'Jellyseerr', 'Lidarr'] },
   { ns: 'automation',   apps: ['n8n', 'Lapineda API'] },
   { ns: 'homeassistant',apps: ['Home Assistant'] },
-  { ns: 'coder',        apps: ['Coder IDE', 'PostgreSQL'] },
   { ns: 'monitoring',   apps: ['Prometheus', 'Grafana', 'Alertmanager', 'Loki', 'Fluent Bit'] },
   { ns: 'rag',          apps: ['Qdrant (vector DB)'] },
   { ns: 'health',       apps: ['Garmin fetcher', 'InfluxDB'] },
-  { ns: 'moltbot',      apps: ['OpenClaw'] },
+  { ns: 'openclaw',     apps: ['Jarvis'] },
   { ns: 'guacamole',    apps: ['Apache Guacamole'] },
   { ns: 'obsidian',     apps: ['LiveSync bridge'] },
 ];
@@ -19,12 +18,12 @@ const namespaces = [
     <div class="section-eyebrow">
       <span class="section-num">02 / Homelab</span>
     </div>
-    <h2 class="section-title">Home cluster.<br/>Always on.</h2>
+    <h2 class="section-title">Homelab infrastructure.<br/>Always on.</h2>
   </div>
 
   <p class="reveal" data-delay="0.05s" style="font-size: 1.05rem; color: var(--fg); margin-bottom: 48px; max-width: 600px; line-height: 1.8;">
     A 3-node K3s cluster running on Proxmox VMs, backed by TrueNAS for shared storage.
-    Fully declarative — Ansible bootstraps, kubectl ships, Sealed Secrets keeps credentials safe in Git.
+    Fully declarative — Ansible bootstraps, Argo CD reconciles, and Sealed Secrets keeps credentials safe in Git.
     Not a tutorial. A real system I depend on daily.
   </p>
 
@@ -104,7 +103,7 @@ const namespaces = [
   <div class="reveal" data-delay="0.25s" style="margin-top: 32px; padding: 20px 24px; border: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap;">
     <div>
       <div class="font-mono" style="font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--amber); margin-bottom: 6px;">GitOps · Fully declarative</div>
-      <div style="font-size: 0.95rem; color: var(--fg-2); line-height: 1.6;">Every node, app, and secret is defined in code. No manual steps, no snowflake servers.</div>
+      <div style="font-size: 0.95rem; color: var(--fg-2); line-height: 1.6;">Platform and workload state is reviewed in Git and reconciled continuously. No snowflake deployments hiding under somebody's desk.</div>
     </div>
     <div style="display: flex; gap: 8px; flex-wrap: wrap;">
       {['Ansible', 'K3s manifests', 'Helm', 'Sealed Secrets', 'Traefik HelmConfig'].map(t => (
@@ -113,15 +112,24 @@ const namespaces = [
     </div>
   </div>
 
-  <!-- WIP note + Jarvis cross-link -->
+  <!-- Public snapshot + Jarvis cross-link -->
   <div class="reveal" data-delay="0.3s" style="margin-top: 24px; display: flex; gap: 24px; flex-wrap: wrap; align-items: center;">
-    <span class="font-mono" style="font-size: 0.75rem; letter-spacing: 0.06em; color: var(--fg-2);">
-      ⌛ repo coming soon — still deciding what's safe to make public
-    </span>
+    <a
+      href="https://github.com/barnolacesc/homelab-infra"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="repo-link font-mono"
+    >
+      View the sanitized public infrastructure repo ↗
+    </a>
     <a href="#jarvis" class="font-mono" style="font-size: 0.75rem; letter-spacing: 0.06em; color: var(--amber); text-decoration: none;">
       → The <code style="color: var(--amber);">openclaw</code> namespace runs Jarvis
     </a>
   </div>
+
+  <p class="reveal font-mono" data-delay="0.32s" style="margin-top: 12px; max-width: 720px; font-size: 0.68rem; line-height: 1.7; color: var(--fg-2);">
+    The public repository is a maintained, sanitized projection of the private source of truth: real architecture and operating patterns, with credentials, personal identifiers, and exploitable topology removed.
+  </p>
 
 </section>
 
@@ -181,6 +189,22 @@ const namespaces = [
   .ns-app {
     font-size: 0.85rem;
     color: var(--fg);
+  }
+
+  .repo-link {
+    display: inline-flex;
+    align-items: center;
+    padding: 10px 14px;
+    border: 1px solid var(--amber);
+    color: var(--amber);
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    text-decoration: none;
+    transition: background 160ms ease, color 160ms ease;
+  }
+  .repo-link:hover {
+    background: var(--amber);
+    color: var(--bg);
   }
 
   @media (max-width: 860px) {

--- a/portfolio-astro/src/components/Jarvis.astro
+++ b/portfolio-astro/src/components/Jarvis.astro
@@ -60,7 +60,7 @@ const capabilities = [
       <div class="font-mono info-label">How it lives</div>
       <ul class="info-list">
         <li>K3s <code class="inline-code">StatefulSet</code> · <code class="inline-code">openclaw</code> namespace</li>
-        <li>ArgoCD GitOps from <code class="inline-code">barnolacesc/home-cluster</code></li>
+        <li>Argo CD GitOps — <a href="https://github.com/barnolacesc/homelab-infra" target="_blank" rel="noopener noreferrer"><code class="inline-code">barnolacesc/homelab-infra</code></a> public architecture</li>
         <li>Sealed Secrets · 2 PVCs · Traefik ingress</li>
         <li>CronJobs: solar-surplus (5 min) · no-ip (monthly)</li>
       </ul>


### PR DESCRIPTION
## Summary
- replace the Homelab “repo coming soon” placeholder with a link to the public `homelab-infra` repository
- explain that the public repository is a maintained, sanitized projection of the private source of truth
- refresh the visible workload inventory and link Jarvis to the public architecture

## Validation
- `npm ci`
- `npm run build`

## Context
The live infrastructure remains private. The linked repository exposes representative architecture and operating patterns without publishing credentials, personal identifiers, or exploitable topology.

The existing GitHub Pages workflow remains unchanged and continues to build and deploy only after pushes to `main`.